### PR TITLE
feat: comment on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:  # yamllint disable-line rule:truthy
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   pgrubic_action:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,36 @@
+---
+name: "PR and Issue Labeler"
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.4
+        with:
+          configuration-path: .github/labeler.yml
+          include-title: 1
+          include-body: 0
+          enable-versioned-regex: 0
+          sync-labels: 1
+          repo-token: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   args:
     description: "Arguments passed to pgrubic. Use `pgrubic --help` to see available options. Defaults to `lint`."
     required: false
-    default: "lint"
+    default: "lint --generate-lint-report"
   src:
     description: "Source to run pgrubic on. Defaults to the current directory."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: bash
 
     - name: Find Comment
-      if: github.event_name == "pull_request"
+      if: github.event_name == 'pull_request'
       uses: peter-evans/find-comment@v3
       id: fc
       with:
@@ -65,7 +65,7 @@ runs:
         body-includes: "Pgrubic Lint Report"
 
     - name: Create or update comment
-      if: github.event_name == "pull_request"
+      if: github.event_name == 'pull_request'
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   pgrubic-version:
     description: "The version of pgrubic to use, e.g., `0.6.0` Defaults 'latest'."
     required: false
-    default: "latest"
+    default: "0.8.0"
 outputs:
   installed-pgrubic-version:
     description: "The installed pgrubic version. Useful when using latest."
@@ -63,6 +63,16 @@ runs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: "github-actions[bot]"
         body-includes: "Pgrubic Lint Report"
+
+    # - name: Check if lint report exists
+    #   id: lint-report
+    #   run: |
+    #     if [ -f pgrubic-lint-report.md ]; then
+    #       echo "exists=true" >> $GITHUB_OUTPUT
+    #     else
+    #       echo "exists=false" >> $GITHUB_OUTPUT
+    #     fi
+    #   shell: bash
 
     - name: Create or update comment
       if: github.event_name == 'pull_request'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   args:
     description: "Arguments passed to pgrubic. Use `pgrubic --help` to see available options. Defaults to `lint`."
     required: false
-    default: "lint --generate-lint-report"
+    default: "lint"
   src:
     description: "Source to run pgrubic on. Defaults to the current directory."
     required: false
@@ -17,7 +17,7 @@ inputs:
   pgrubic-version:
     description: "The version of pgrubic to use, e.g., `0.6.0` Defaults 'latest'."
     required: false
-    default: "0.8.0"
+    default: "latest"
 outputs:
   installed-pgrubic-version:
     description: "The installed pgrubic version. Useful when using latest."

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   args:
     description: "Arguments passed to pgrubic. Use `pgrubic --help` to see available options. Defaults to `lint`."
     required: false
-    default: "lint"
+    default: "lint --generate-lint-report"
   src:
     description: "Source to run pgrubic on. Defaults to the current directory."
     required: false
@@ -30,23 +30,43 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+
     - name: Install pgrubic {{ inputs.pgrubic-version }}
       if: ${{ inputs.pgrubic-version == 'latest' }}
       run: pip install --upgrade pip pgrubic
       shell: bash
+
     - name: Install pgrubic {{ inputs.pgrubic-version }}
       if: ${{ inputs.pgrubic-version != 'latest' }}
       env:
         PGRUBIC_VERSION: ${{ inputs.pgrubic-version }}
       run: pip install --upgrade pip pgrubic==$PGRUBIC_VERSION
       shell: bash
+
     - name: Output installed pgrubic version
       id: installed-pgrubic-version
       run: echo "installed-pgrubic-version=$(pgrubic --version)" >> $GITHUB_OUTPUT
       shell: bash
+
     - name: Run pgrubic
       env:
         PGRUBIC_ARGS: ${{ inputs.args }}
         PGRUBIC_SRC: ${{ inputs.src }}
       run: pgrubic $PGRUBIC_ARGS $PGRUBIC_SRC
       shell: bash
+
+    - name: Find Comment
+      uses: peter-evans/find-comment@v3
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: "github-actions[bot]"
+        body-includes: "Pgrubic Lint Report"
+
+    - name: Create or update comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body-path: "pgrubic-lint-report.md"
+        edit-mode: replace

--- a/action.yml
+++ b/action.yml
@@ -64,18 +64,18 @@ runs:
         comment-author: "github-actions[bot]"
         body-includes: "Pgrubic Lint Report"
 
-    # - name: Check if lint report exists
-    #   id: lint-report
-    #   run: |
-    #     if [ -f pgrubic-lint-report.md ]; then
-    #       echo "exists=true" >> $GITHUB_OUTPUT
-    #     else
-    #       echo "exists=false" >> $GITHUB_OUTPUT
-    #     fi
-    #   shell: bash
+    - name: Check if lint report exists
+      id: lint-report
+      run: |
+        if [ -f pgrubic-lint-report.md ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
 
     - name: Create or update comment
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && steps.lint-report.outputs.exists == 'true'
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,7 @@ runs:
       shell: bash
 
     - name: Find Comment
+      if: github.event_name == "pull_request"
       uses: peter-evans/find-comment@v3
       id: fc
       with:
@@ -64,6 +65,7 @@ runs:
         body-includes: "Pgrubic Lint Report"
 
     - name: Create or update comment
+      if: github.event_name == "pull_request"
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
This pull request adds functionality to comment on pull requests with lint report results from the pgrubic linting tool. The changes enable the GitHub Action to automatically generate and post lint reports as PR comments, providing immediate feedback to developers.

- Modified the default arguments to include `--generate-lint-report` flag
- Added steps to find existing comments and create/update PR comments with lint results
- Enhanced workflow formatting with additional spacing between steps

When using versions with no support for lint report:
```
Run pgrubic $PGRUBIC_ARGS $PGRUBIC_SRC
Usage: pgrubic lint [OPTIONS] [SOURCES]...
Try 'pgrubic lint -h' for help.

Error: No such option: --generate-lint-report
```

When running with no lint report:
```
Error: File 'pgrubic-lint-report.md' does not exist.
```