### PR TITLE
fix: comment lint report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
       - name: Self test action
         id: action
         uses: ./
+        with:
+          src: "tests/sql"
+
       - name: Output installed pgrubic version
         run: echo ${{ steps.action.outputs.installed-pgrubic-version }}

--- a/action.yml
+++ b/action.yml
@@ -49,11 +49,13 @@ runs:
       shell: bash
 
     - name: Run pgrubic
+      id: run-pgrubic
       env:
         PGRUBIC_ARGS: ${{ inputs.args }}
         PGRUBIC_SRC: ${{ inputs.src }}
       run: pgrubic $PGRUBIC_ARGS $PGRUBIC_SRC
       shell: bash
+      continue-on-error: true
 
     - name: Find Comment
       if: github.event_name == 'pull_request'
@@ -82,3 +84,9 @@ runs:
         issue-number: ${{ github.event.pull_request.number }}
         body-path: "pgrubic-lint-report.md"
         edit-mode: replace
+
+    - name: Exit pipeline on pgrubic failure
+      if: steps.run-pgrubic.outcome  == 'failure'
+      run: |
+        exit 1
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         edit-mode: replace
 
     - name: Exit pipeline on pgrubic failure
-      if: steps.run-pgrubic.outcome  == 'failure'
+      if: steps.run-pgrubic.outcome == 'failure'
       run: |
         exit 1
       shell: bash

--- a/tests/sql/V001__init.sql
+++ b/tests/sql/V001__init.sql
@@ -1,0 +1,3 @@
+SELECT *
+  FROM public.t1
+ WHERE 12 = d1;

--- a/tests/sql/V001__init.sql
+++ b/tests/sql/V001__init.sql
@@ -1,3 +1,3 @@
-SELECT *
+SELECT col1
   FROM public.t1
- WHERE 12 = d1;
+ WHERE d1 = 12;


### PR DESCRIPTION
This PR fixes comment lint reporting functionality by implementing proper error handling and test infrastructure for the pgrubic action. The changes ensure that pgrubic can run and report results through GitHub comments while still properly failing the pipeline when issues are detected.

- Added `continue-on-error: true` to allow pgrubic to complete and generate reports even when lint issues are found
- Implemented proper pipeline failure handling that exits after comment reporting is complete
- Added test SQL file and configured CI workflow to test the action with actual SQL content